### PR TITLE
Gokogiri benchmark fix

### DIFF
--- a/golang/src/bench_gokogiri/main.go
+++ b/golang/src/bench_gokogiri/main.go
@@ -32,6 +32,7 @@ func main() {
 			panic(err)
 		}
 		doc.Root()
+		doc.Free()
 	}
 	end := time.Now()
 


### PR DESCRIPTION
Увидел результаты на Хабрахабр и понял, что в тесте gokogiri забыл освободить память после парсинга документа (gokogiri - обертка libxml).
